### PR TITLE
fix: add cron skill frontmatter

### DIFF
--- a/assets/skills/codex-claw-cronjob-creator/SKILL.md
+++ b/assets/skills/codex-claw-cronjob-creator/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: codex-claw-cronjob-creator
+description: Create or update codex-claw scheduled job definitions under ~/.codex-claw/cronjobs.
+---
+
 # codex-claw-cronjob-creator
 
 Create or update scheduled job definitions for `codex-claw`.

--- a/tests/unit/runtime-workspace.test.ts
+++ b/tests/unit/runtime-workspace.test.ts
@@ -12,9 +12,13 @@ describe("installCronjobCreatorSkill", () => {
 
     try {
       const installedPath = await installCronjobCreatorSkill({ codexHomeDir });
+      const installedSkill = readFileSync(installedPath, "utf8");
 
       expect(statSync(installedPath).isFile()).toBe(true);
-      expect(readFileSync(installedPath, "utf8")).toContain("# codex-claw-cronjob-creator");
+      expect(installedSkill.startsWith("---\n")).toBe(true);
+      expect(installedSkill).toContain("name: codex-claw-cronjob-creator");
+      expect(installedSkill).toContain("description:");
+      expect(installedSkill).toContain("# codex-claw-cronjob-creator");
     } finally {
       rmSync(root, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Summary
- add official Claude skill YAML frontmatter to the packaged cron creator `SKILL.md`
- extend the runtime workspace test to assert the packaged default skill includes `name` and `description` metadata

## Verification
- `bun test tests/unit/runtime-workspace.test.ts`
- `bun test`
- `bun run typecheck`
