### PR TITLE
feat: add Telegram message bundle intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,38 @@ Example:
 2. `그럼 다음으로 테스트부터 돌려봐`
 3. `방금 수정한 내용 요약해줘`
 
+## Telegram Attachments
+
+`codex-claw` treats one Telegram attachment message as one Codex turn.
+
+- Supported attachment types: `document`, `photo`
+- `document` messages save the uploaded file locally before the turn runs
+- `photo` messages save only the largest Telegram photo variant
+- `photo` messages that share the same Telegram `media_group_id` are coalesced into one Codex turn
+- The attachment caption becomes the primary user request for Codex
+- Attachment paths and metadata are appended as structured context
+- Later plain-text follow-up messages do not automatically re-inject earlier attachment bundles
+
+Saved attachment bundles live under:
+
+```text
+~/.codex-claw/workspace/inbox/<chatId>/<messageId>/
+```
+
+Each bundle directory keeps the downloaded files plus:
+
+```text
+bundle.json
+```
+
+`bundle.json` records the Telegram `chatId`, `messageId`, caption, successful `attachments`, and `failedAttachments`.
+
+Notes:
+
+- If some attachments fail to download, successful files are still saved and the failure metadata is included in the Codex prompt
+- If all attachments fail but the caption exists, Codex still receives the caption plus failure metadata
+- Bundles are kept until later cleanup work; there is no automatic deletion yet
+
 ## Scheduled Jobs
 
 `codex-claw` can run scheduled Codex prompts from JSON definitions stored under:

--- a/docs/plans/2026-03-10-telegram-message-bundle-intake.md
+++ b/docs/plans/2026-03-10-telegram-message-bundle-intake.md
@@ -1,0 +1,266 @@
+# Telegram Message Bundle Intake Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement Telegram attachment intake so a single Telegram message containing caption plus `document`/`photo` attachments is saved as one local bundle and sent to Codex as one turn.
+
+**Architecture:** Add a dedicated message-bundle module that normalizes Telegram `document` and `photo` inputs into one bundle, stores all successful attachments under `~/.codex-claw/workspace/inbox/<chatId>/<messageId>/`, writes a `bundle.json` metadata file, and composes a structured prompt where the caption is the main request and attachments are supplemental context. Wire this through the existing bot/runtime path without automatic attachment reinjection on later messages.
+
+**Tech Stack:** Bun, TypeScript, grammY, native `fetch`, local filesystem, existing Codex runtime path
+
+---
+
+### Task 1: Define Bundle Types And Prompt Shape
+
+**Files:**
+- Create: `src/files/telegram-message-bundle.ts`
+- Create: `tests/unit/telegram-message-bundle.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add unit tests that define the desired prompt/bundle shape:
+- caption becomes the main user request
+- attachments are listed in a structured text block
+- failed attachments are listed separately with `name + reason`
+- caption-less messages produce a short default request
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bun test tests/unit/telegram-message-bundle.test.ts
+```
+
+Expected: fail because the new module does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement in `src/files/telegram-message-bundle.ts`:
+- bundle metadata types
+- attachment metadata types
+- failed attachment types
+- prompt composer for:
+  - caption present
+  - caption absent
+  - mixed success/failure attachments
+
+The prompt must have these sections in plain structured text:
+- `User caption`
+- `Attachments`
+- `Failed attachments`
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bun test tests/unit/telegram-message-bundle.test.ts
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/files/telegram-message-bundle.ts tests/unit/telegram-message-bundle.test.ts
+git commit -m "feat: add Telegram message bundle prompt builder"
+```
+
+### Task 2: Build Inbox Storage For Bundle Directories
+
+**Files:**
+- Modify: `src/files/telegram-message-bundle.ts`
+- Modify: `src/runtime/workspace.ts`
+- Modify: `tests/unit/telegram-message-bundle.test.ts`
+- Modify: `tests/unit/runtime-workspace.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add tests for storage behavior:
+- bundle path is `workspace/inbox/<chatId>/<messageId>/`
+- `document` attachments save with stable sanitized names
+- `photo` saves only the largest resolution entry
+- successful attachments are written to disk
+- `bundle.json` is written with caption, message id, attachments, failed attachments
+- partial failures still write successful files plus failure metadata
+- workspace bootstrap creates `inbox/`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bun test tests/unit/telegram-message-bundle.test.ts tests/unit/runtime-workspace.test.ts
+```
+
+Expected: FAIL on missing storage behavior.
+
+**Step 3: Write minimal implementation**
+
+Extend `src/files/telegram-message-bundle.ts` to:
+- resolve bundle directory from `workspaceDir`, `chatId`, `messageId`
+- save `document` and `photo` attachments into the bundle directory
+- persist `bundle.json`
+- preserve successful attachments even when some downloads fail
+- keep failed attachments as `name + reason`
+
+Update `src/runtime/workspace.ts` so `workspace/inbox` exists at startup.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bun test tests/unit/telegram-message-bundle.test.ts tests/unit/runtime-workspace.test.ts
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/files/telegram-message-bundle.ts src/runtime/workspace.ts tests/unit/telegram-message-bundle.test.ts tests/unit/runtime-workspace.test.ts
+git commit -m "feat: add Telegram bundle inbox storage"
+```
+
+### Task 3: Wire Telegram Message Bundle Intake Into Bot Flow
+
+**Files:**
+- Modify: `src/bot/create-bot.ts`
+- Modify: `src/index.ts`
+- Modify: `tests/integration/create-bot.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add integration tests that define the bot behavior:
+- a `document` message with caption becomes one Codex turn
+- a `photo` message with caption becomes one Codex turn
+- multiple attachments from one message become one synthesized prompt
+- partial failures still call `runTurn` with successful attachments and failed attachment metadata
+- all attachments failed but caption exists still calls `runTurn`
+- if attachment extraction throws before bundle creation, user gets an explicit failure reply and `runTurn` is not called
+- no automatic attachment reinjection on later plain-text follow-ups
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bun test tests/integration/create-bot.test.ts
+```
+
+Expected: FAIL because document/photo bundle wiring does not exist.
+
+**Step 3: Write minimal implementation**
+
+Update `src/bot/create-bot.ts` and `src/index.ts` to:
+- detect `message:document`
+- detect `message:photo`
+- normalize both into one bundle input
+- store the bundle locally
+- compose one Codex prompt from caption + structured attachment context
+- call the existing `runTurn` path exactly once per Telegram message
+- send explicit user-facing failure replies only when the bundle cannot be prepared at all
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bun test tests/integration/create-bot.test.ts
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/bot/create-bot.ts src/index.ts tests/integration/create-bot.test.ts
+git commit -m "feat: wire Telegram message bundles into Codex turns"
+```
+
+### Task 4: Final Docs, Regression Coverage, And Full Verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `tests/smoke/readme.test.ts`
+- Modify: `tests/unit/telegram-message-bundle.test.ts`
+- Modify: `tests/integration/create-bot.test.ts`
+
+**Step 1: Add final regression coverage**
+
+Add the remaining tests for:
+- bundle directory naming by `messageId`
+- no auto reinjection on later turns
+- `photo` largest-size selection
+- bundle metadata file shape
+
+**Step 2: Update docs**
+
+Document in `README.md`:
+- supported attachment types: `document`, `photo`
+- bundle directory layout under `workspace/inbox`
+- `message 1 = Codex turn 1`
+- caption as primary request
+- retention policy: keep bundles until later cleanup work
+
+**Step 3: Run full verification**
+
+Run:
+
+```bash
+bun test
+bun run typecheck
+```
+
+Expected: all tests pass, typecheck exits 0.
+
+**Step 4: Commit**
+
+```bash
+git add README.md tests/smoke/readme.test.ts tests/unit/telegram-message-bundle.test.ts tests/integration/create-bot.test.ts
+git commit -m "docs: finalize Telegram message bundle intake"
+```
+
+### Task 5: Review And Prepare Merge
+
+**Files:**
+- Verify only: `git diff --stat`
+- Verify only: PR summary
+
+**Step 1: Request code review**
+
+Use review pass focused on:
+- Telegram boundary correctness
+- partial failure behavior
+- no unintended state carry-over
+
+**Step 2: Re-run fresh verification**
+
+Run:
+
+```bash
+bun test
+bun run typecheck
+```
+
+Expected: PASS
+
+**Step 3: Create PR**
+
+Suggested PR title:
+
+```text
+feat: add Telegram message bundle intake for Codex
+```
+
+Suggested PR body should mention:
+- `document + photo`
+- `messageId` bundle directories
+- caption as primary prompt
+- `failed_attachments` handling
+
+**Step 4: Stop**
+
+Do not merge without explicit user approval.

--- a/src/bot/create-bot.ts
+++ b/src/bot/create-bot.ts
@@ -1,4 +1,11 @@
 import type { Bot, Context } from "grammy";
+import type {
+  TelegramDocumentAttachmentInput,
+  TelegramFailedAttachment,
+  TelegramMessageAttachmentInput,
+  TelegramPhotoAttachmentInput,
+  TelegramPhotoVariantInput,
+} from "../files/telegram-message-bundle";
 import type { AbortRunResult, ResetSessionResult } from "../runtime/agent-runtime";
 import { parseCommand } from "./commands";
 import {
@@ -13,6 +20,7 @@ import { createTypingHeartbeat } from "./typing-heartbeat";
 type Reply = (value: string) => Promise<void> | void;
 type StopTyping = (() => Promise<void> | void) | void;
 type StartTyping = () => Promise<StopTyping> | StopTyping;
+type TimeoutHandle = ReturnType<typeof setTimeout>;
 
 export type BotTextInput = {
   chatId: bigint;
@@ -21,10 +29,57 @@ export type BotTextInput = {
   reply: Reply;
 };
 
+type DownloadAttachment = () => Promise<Uint8Array>;
+
+export type BotDocumentAttachmentInput = {
+  kind: "document";
+  name: string;
+  mimeType?: string | null;
+  download: DownloadAttachment;
+};
+
+export type BotPhotoVariantInput = {
+  name: string;
+  width: number;
+  height: number;
+  mimeType?: string | null;
+  download: DownloadAttachment;
+};
+
+export type BotPhotoAttachmentInput = {
+  kind: "photo";
+  name: string;
+  variants: BotPhotoVariantInput[];
+};
+
+export type BotAttachmentInput = BotDocumentAttachmentInput | BotPhotoAttachmentInput;
+
+export type BotAttachmentMessageInput = {
+  chatId: bigint;
+  messageId: number;
+  caption?: string | null;
+  attachments: BotAttachmentInput[];
+  startTyping?: StartTyping;
+  reply: Reply;
+};
+
+export type PrepareAttachmentPromptInput = {
+  chatId: number;
+  messageId: number;
+  caption?: string | null;
+  attachments: TelegramMessageAttachmentInput[];
+  failedAttachments: TelegramFailedAttachment[];
+};
+
 export type CreateBotHandlersDeps = {
   getStatusMessage: (chatId: bigint) => Promise<string>;
   resetSession: (chatId: bigint) => Promise<ResetSessionResult>;
   abortRun: (chatId: bigint) => Promise<AbortRunResult>;
+  prepareAttachmentPrompt?: (
+    input: PrepareAttachmentPromptInput,
+  ) => Promise<{
+    prompt: string;
+  }>;
   runTurn: (
     chatId: bigint,
     prompt: string,
@@ -33,30 +88,29 @@ export type CreateBotHandlersDeps = {
   }>;
 };
 
+type RegisterBotHandlersOptions = {
+  mediaGroupDebounceMs?: number;
+  setTimeoutFn?: (callback: () => void, delayMs: number) => TimeoutHandle;
+  clearTimeoutFn?: (handle: TimeoutHandle) => void;
+};
+
+type PendingPhotoMediaGroup = {
+  chatId: bigint;
+  messageId: number;
+  caption?: string | null;
+  attachments: BotPhotoAttachmentInput[];
+  startTyping?: StartTyping;
+  reply: Reply;
+  timer: TimeoutHandle | null;
+};
+
 export function createBotHandlers(deps: CreateBotHandlersDeps) {
   return {
     async onText({ chatId, text, startTyping, reply }: BotTextInput): Promise<void> {
-      const stopTyping = await startTyping?.();
-      let typingStopped = false;
+      const command = parseCommand(text);
 
-      const stopTypingOnce = async () => {
-        if (typingStopped) {
-          return;
-        }
-
-        typingStopped = true;
-        await stopTyping?.();
-      };
-
-      const replyAfterStoppingTyping = async (value: string) => {
-        await stopTypingOnce();
-        await reply(value);
-      };
-
-      try {
-        const command = parseCommand(text);
-
-        if (command) {
+      if (command) {
+        return withTyping(startTyping, reply, async (replyAfterStoppingTyping) => {
           switch (command.name) {
             case "start":
             case "help":
@@ -68,34 +122,90 @@ export function createBotHandlers(deps: CreateBotHandlersDeps) {
             case "reset":
               await replyAfterStoppingTyping(formatResetMessage(await deps.resetSession(chatId)));
               return;
-            case "abort": {
+            case "abort":
               await replyAfterStoppingTyping(formatAbortMessage(await deps.abortRun(chatId)));
               return;
-            }
           }
+        });
+      }
+
+      await runPromptAndReply({
+        chatId,
+        prompt: text,
+        startTyping,
+        reply,
+        runTurn: deps.runTurn,
+      });
+    },
+
+    async onAttachmentMessage({
+      chatId,
+      messageId,
+      caption,
+      attachments,
+      startTyping,
+      reply,
+    }: BotAttachmentMessageInput): Promise<void> {
+      await withTyping(startTyping, reply, async (replyAfterStoppingTyping) => {
+        const prepareAttachmentPrompt = deps.prepareAttachmentPrompt;
+
+        if (!prepareAttachmentPrompt) {
+          await replyAfterStoppingTyping("Attachment handling is not configured.");
+          return;
         }
+
+        const preparedAttachments: TelegramMessageAttachmentInput[] = [];
+        const failedAttachments: TelegramFailedAttachment[] = [];
+
+        for (const attachment of attachments) {
+          if (attachment.kind === "document") {
+            await prepareDocumentAttachment(attachment, preparedAttachments, failedAttachments);
+            continue;
+          }
+
+          await preparePhotoAttachment(attachment, preparedAttachments, failedAttachments);
+        }
+
+        let prompt: string;
 
         try {
-          const result = await deps.runTurn(chatId, text);
-          await replyAfterStoppingTyping(formatRunCompletedMessage(result.summary ?? null));
-        } catch (error) {
-          if (isAbortError(error)) {
-            await replyAfterStoppingTyping(formatRunAbortedMessage());
-            return;
-          }
+          const prepared = await prepareAttachmentPrompt({
+            chatId: toNumberChatId(chatId),
+            messageId,
+            caption,
+            attachments: preparedAttachments,
+            failedAttachments,
+          });
 
-          const message = error instanceof Error ? error.message : String(error);
-          await replyAfterStoppingTyping(formatRunFailedMessage(message));
+          prompt = prepared.prompt;
+        } catch (error) {
+          await replyAfterStoppingTyping(formatAttachmentPrepareFailedMessage(error));
+          return;
         }
-      } finally {
-        await stopTypingOnce();
-      }
+
+        await runPromptAndReply({
+          chatId,
+          prompt,
+          startTyping: undefined,
+          reply,
+          runTurn: deps.runTurn,
+          replyAfterStoppingTyping,
+        });
+      });
     },
   };
 }
 
-export function registerBotHandlers(bot: Bot<Context>, deps: CreateBotHandlersDeps) {
+export function registerBotHandlers(
+  bot: Bot<Context>,
+  deps: CreateBotHandlersDeps,
+  options: RegisterBotHandlersOptions = {},
+) {
   const handlers = createBotHandlers(deps);
+  const pendingPhotoMediaGroups = new Map<string, PendingPhotoMediaGroup>();
+  const setTimeoutFn = options.setTimeoutFn ?? setTimeout;
+  const clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
+  const mediaGroupDebounceMs = options.mediaGroupDebounceMs ?? 150;
 
   bot.on("message:text", async (ctx) => {
     await handlers.onText({
@@ -113,7 +223,363 @@ export function registerBotHandlers(bot: Bot<Context>, deps: CreateBotHandlersDe
     });
   });
 
+  bot.on("message:document", async (ctx) => {
+    const document = ctx.message.document;
+
+    await handlers.onAttachmentMessage({
+      chatId: BigInt(String(ctx.chat.id)),
+      messageId: ctx.message.message_id,
+      caption: ctx.message.caption,
+      attachments: [
+        {
+          kind: "document",
+          name: document.file_name ?? `document-${document.file_unique_id}`,
+          mimeType: document.mime_type,
+          download: () => downloadTelegramFile(bot.token, ctx, document.file_id),
+        },
+      ],
+      startTyping: () =>
+        createTypingHeartbeat({
+          sendTyping: async () => {
+            await ctx.replyWithChatAction("typing");
+          },
+        }),
+      reply: async (value) => {
+        await ctx.reply(value);
+      },
+    });
+  });
+
+  bot.on("message:photo", async (ctx) => {
+    const largestPhoto = pickLargestTelegramPhoto(ctx.message.photo);
+    const photoAttachment: BotPhotoAttachmentInput = {
+      kind: "photo",
+      name: buildTelegramPhotoName(ctx.message.message_id, largestPhoto?.file_unique_id),
+      variants: largestPhoto
+        ? [
+            {
+              name: buildTelegramPhotoName(ctx.message.message_id, largestPhoto.file_unique_id),
+              width: largestPhoto.width,
+              height: largestPhoto.height,
+              mimeType: "image/jpeg",
+              download: () => downloadTelegramFile(bot.token, ctx, largestPhoto.file_id),
+            },
+          ]
+        : [],
+    };
+    const mediaGroupId = ctx.message.media_group_id;
+
+    if (!mediaGroupId) {
+      await handlers.onAttachmentMessage({
+        chatId: BigInt(String(ctx.chat.id)),
+        messageId: ctx.message.message_id,
+        caption: ctx.message.caption,
+        attachments: [photoAttachment],
+        startTyping: () =>
+          createTypingHeartbeat({
+            sendTyping: async () => {
+              await ctx.replyWithChatAction("typing");
+            },
+          }),
+        reply: async (value) => {
+          await ctx.reply(value);
+        },
+      });
+      return;
+    }
+
+    queuePhotoMediaGroupAttachment({
+      mediaGroupId,
+      attachment: photoAttachment,
+      chatId: BigInt(String(ctx.chat.id)),
+      messageId: ctx.message.message_id,
+      caption: ctx.message.caption,
+      startTyping: () =>
+        createTypingHeartbeat({
+          sendTyping: async () => {
+            await ctx.replyWithChatAction("typing");
+          },
+        }),
+      reply: async (value) => {
+        await ctx.reply(value);
+      },
+      handlers,
+      pendingPhotoMediaGroups,
+      mediaGroupDebounceMs,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+  });
+
   return handlers;
+}
+
+async function runPromptAndReply({
+  chatId,
+  prompt,
+  startTyping,
+  reply,
+  runTurn,
+  replyAfterStoppingTyping,
+}: {
+  chatId: bigint;
+  prompt: string;
+  startTyping?: StartTyping;
+  reply: Reply;
+  runTurn: CreateBotHandlersDeps["runTurn"];
+  replyAfterStoppingTyping?: (value: string) => Promise<void>;
+}): Promise<void> {
+  await withTyping(startTyping, reply, async (localReplyAfterStoppingTyping) => {
+    const sendReply = replyAfterStoppingTyping ?? localReplyAfterStoppingTyping;
+
+    try {
+      const result = await runTurn(chatId, prompt);
+      await sendReply(formatRunCompletedMessage(result.summary ?? null));
+    } catch (error) {
+      if (isAbortError(error)) {
+        await sendReply(formatRunAbortedMessage());
+        return;
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      await sendReply(formatRunFailedMessage(message));
+    }
+  });
+}
+
+async function withTyping(
+  startTyping: StartTyping | undefined,
+  reply: Reply,
+  fn: (replyAfterStoppingTyping: (value: string) => Promise<void>) => Promise<void>,
+): Promise<void> {
+  const stopTyping = await startTyping?.();
+  let typingStopped = false;
+
+  const stopTypingOnce = async () => {
+    if (typingStopped) {
+      return;
+    }
+
+    typingStopped = true;
+    await stopTyping?.();
+  };
+
+  const replyAfterStoppingTyping = async (value: string) => {
+    await stopTypingOnce();
+    await reply(value);
+  };
+
+  try {
+    await fn(replyAfterStoppingTyping);
+  } finally {
+    await stopTypingOnce();
+  }
+}
+
+async function prepareDocumentAttachment(
+  attachment: BotDocumentAttachmentInput,
+  preparedAttachments: TelegramMessageAttachmentInput[],
+  failedAttachments: TelegramFailedAttachment[],
+): Promise<void> {
+  try {
+    preparedAttachments.push({
+      kind: "document",
+      name: attachment.name,
+      mimeType: attachment.mimeType,
+      bytes: await attachment.download(),
+    } satisfies TelegramDocumentAttachmentInput);
+  } catch (error) {
+    failedAttachments.push({
+      name: attachment.name,
+      reason: getFailureReason(error),
+    });
+  }
+}
+
+async function preparePhotoAttachment(
+  attachment: BotPhotoAttachmentInput,
+  preparedAttachments: TelegramMessageAttachmentInput[],
+  failedAttachments: TelegramFailedAttachment[],
+): Promise<void> {
+  const largestVariant = pickLargestDownloadablePhotoVariant(attachment.variants);
+
+  if (!largestVariant) {
+    failedAttachments.push({
+      name: attachment.name,
+      reason: "photo has no variants",
+    });
+    return;
+  }
+
+  try {
+    preparedAttachments.push({
+      kind: "photo",
+      name: attachment.name,
+      variants: [
+        {
+          name: largestVariant.name,
+          width: largestVariant.width,
+          height: largestVariant.height,
+          mimeType: largestVariant.mimeType,
+          bytes: await largestVariant.download(),
+        },
+      ],
+    } satisfies TelegramPhotoAttachmentInput);
+  } catch (error) {
+    failedAttachments.push({
+      name: attachment.name,
+      reason: getFailureReason(error),
+    });
+  }
+}
+
+function pickLargestDownloadablePhotoVariant(
+  variants: BotPhotoVariantInput[],
+): BotPhotoVariantInput | null {
+  if (variants.length === 0) {
+    return null;
+  }
+
+  return variants.reduce((largest, current) =>
+    current.width * current.height > largest.width * largest.height ? current : largest,
+  );
+}
+
+function pickLargestTelegramPhoto(
+  photos: Array<{
+    file_id: string;
+    file_unique_id: string;
+    width: number;
+    height: number;
+  }>,
+):
+  | {
+      file_id: string;
+      file_unique_id: string;
+      width: number;
+      height: number;
+    }
+  | null {
+  if (photos.length === 0) {
+    return null;
+  }
+
+  return photos.reduce((largest, current) =>
+    current.width * current.height > largest.width * largest.height ? current : largest,
+  );
+}
+
+function queuePhotoMediaGroupAttachment({
+  mediaGroupId,
+  attachment,
+  chatId,
+  messageId,
+  caption,
+  startTyping,
+  reply,
+  handlers,
+  pendingPhotoMediaGroups,
+  mediaGroupDebounceMs,
+  setTimeoutFn,
+  clearTimeoutFn,
+}: {
+  mediaGroupId: string;
+  attachment: BotPhotoAttachmentInput;
+  chatId: bigint;
+  messageId: number;
+  caption?: string | null;
+  startTyping?: StartTyping;
+  reply: Reply;
+  handlers: ReturnType<typeof createBotHandlers>;
+  pendingPhotoMediaGroups: Map<string, PendingPhotoMediaGroup>;
+  mediaGroupDebounceMs: number;
+  setTimeoutFn: (callback: () => void, delayMs: number) => TimeoutHandle;
+  clearTimeoutFn: (handle: TimeoutHandle) => void;
+}): void {
+  const key = `${chatId.toString()}:${mediaGroupId}`;
+  const pendingGroup =
+    pendingPhotoMediaGroups.get(key) ??
+    ({
+      chatId,
+      messageId,
+      caption,
+      attachments: [],
+      startTyping,
+      reply,
+      timer: null,
+    } satisfies PendingPhotoMediaGroup);
+
+  pendingGroup.attachments.push(attachment);
+
+  if (!pendingGroup.caption && caption) {
+    pendingGroup.caption = caption;
+  }
+
+  if (messageId < pendingGroup.messageId) {
+    pendingGroup.messageId = messageId;
+  }
+
+  if (pendingGroup.timer !== null) {
+    clearTimeoutFn(pendingGroup.timer);
+  }
+
+  pendingGroup.timer = setTimeoutFn(() => {
+    pendingPhotoMediaGroups.delete(key);
+    void handlers.onAttachmentMessage({
+      chatId: pendingGroup.chatId,
+      messageId: pendingGroup.messageId,
+      caption: pendingGroup.caption,
+      attachments: pendingGroup.attachments,
+      startTyping: pendingGroup.startTyping,
+      reply: pendingGroup.reply,
+    });
+  }, mediaGroupDebounceMs);
+
+  pendingPhotoMediaGroups.set(key, pendingGroup);
+}
+
+async function downloadTelegramFile(
+  token: string,
+  ctx: Context,
+  fileId: string,
+): Promise<Uint8Array> {
+  const file = await ctx.api.getFile(fileId);
+
+  if (!file.file_path) {
+    throw new Error("telegram file path missing");
+  }
+
+  const response = await fetch(`https://api.telegram.org/file/bot${token}/${file.file_path}`);
+
+  if (!response.ok) {
+    throw new Error(`telegram download failed (${response.status})`);
+  }
+
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+function buildTelegramPhotoName(messageId: number, fileUniqueId?: string): string {
+  return fileUniqueId ? `photo-${fileUniqueId}.jpg` : `photo-${messageId}.jpg`;
+}
+
+function formatAttachmentPrepareFailedMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return `Failed to prepare attachment bundle: ${message}`;
+}
+
+function getFailureReason(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown error";
+}
+
+function toNumberChatId(chatId: bigint): number {
+  const value = Number(chatId);
+
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`chat id ${chatId} is not a safe integer`);
+  }
+
+  return value;
 }
 
 function buildHelpMessage(): string {

--- a/src/files/telegram-message-bundle.ts
+++ b/src/files/telegram-message-bundle.ts
@@ -1,0 +1,291 @@
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export type TelegramAttachmentKind = "document" | "photo";
+
+export type TelegramMessageAttachment = {
+  kind: TelegramAttachmentKind;
+  name: string;
+  path: string;
+  mimeType?: string | null;
+  sizeBytes?: number | null;
+};
+
+export type TelegramFailedAttachment = {
+  name: string;
+  reason: string;
+};
+
+export type TelegramMessageBundle = {
+  chatId: number;
+  messageId: number;
+  caption?: string | null;
+  attachments: TelegramMessageAttachment[];
+  failedAttachments: TelegramFailedAttachment[];
+};
+
+export type TelegramAttachmentBytes = ArrayBuffer | Uint8Array;
+
+export type TelegramDocumentAttachmentInput = {
+  kind: "document";
+  name: string;
+  bytes: TelegramAttachmentBytes;
+  mimeType?: string | null;
+};
+
+export type TelegramPhotoVariantInput = {
+  name: string;
+  width: number;
+  height: number;
+  bytes: TelegramAttachmentBytes;
+  mimeType?: string | null;
+};
+
+export type TelegramPhotoAttachmentInput = {
+  kind: "photo";
+  name: string;
+  variants: TelegramPhotoVariantInput[];
+};
+
+export type TelegramMessageAttachmentInput =
+  | TelegramDocumentAttachmentInput
+  | TelegramPhotoAttachmentInput;
+
+export type SaveTelegramMessageBundleInput = {
+  workspaceDir: string;
+  chatId: number;
+  messageId: number;
+  caption?: string | null;
+  attachments: TelegramMessageAttachmentInput[];
+};
+
+export type SavedTelegramMessageBundle = {
+  bundleDir: string;
+  bundleJsonPath: string;
+  bundle: TelegramMessageBundle;
+};
+
+const DEFAULT_REQUEST =
+  "The user uploaded Telegram attachments. Review the saved files and continue with the appropriate next step.";
+
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]+/g;
+
+export function getTelegramMessageBundleDirectory(
+  workspaceDir: string,
+  chatId: number,
+  messageId: number,
+): string {
+  return path.join(workspaceDir, "inbox", String(chatId), String(messageId));
+}
+
+export async function saveTelegramMessageBundle(
+  input: SaveTelegramMessageBundleInput,
+): Promise<SavedTelegramMessageBundle> {
+  const bundleDir = getTelegramMessageBundleDirectory(
+    input.workspaceDir,
+    input.chatId,
+    input.messageId,
+  );
+  await mkdir(bundleDir, { recursive: true });
+
+  const attachments: TelegramMessageAttachment[] = [];
+  const failedAttachments: TelegramFailedAttachment[] = [];
+
+  for (const [index, attachment] of input.attachments.entries()) {
+    try {
+      attachments.push(await saveAttachment(bundleDir, index, attachment));
+    } catch (error) {
+      failedAttachments.push({
+        name: sanitizeTelegramAttachmentName(
+          attachment.name,
+          attachment.kind === "photo" ? "photo.jpg" : "document.bin",
+        ),
+        reason: getFailureReason(error),
+      });
+    }
+  }
+
+  const bundle: TelegramMessageBundle = {
+    chatId: input.chatId,
+    messageId: input.messageId,
+    caption: input.caption ?? null,
+    attachments,
+    failedAttachments,
+  };
+  const bundleJsonPath = path.join(bundleDir, "bundle.json");
+
+  await writeTelegramMessageBundleJson(bundleJsonPath, bundle);
+
+  return {
+    bundleDir,
+    bundleJsonPath,
+    bundle,
+  };
+}
+
+export async function writeTelegramMessageBundleJson(
+  bundleJsonPath: string,
+  bundle: TelegramMessageBundle,
+): Promise<void> {
+  const temporaryPath = `${bundleJsonPath}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`;
+
+  await writeFile(temporaryPath, JSON.stringify(bundle, null, 2));
+  await rename(temporaryPath, bundleJsonPath);
+}
+
+export function composeTelegramMessageBundlePrompt(bundle: TelegramMessageBundle): string {
+  const sections = [
+    ["User caption", composeCaptionSection(bundle.caption)],
+    ["Attachments", composeAttachmentsSection(bundle.attachments)],
+    ["Failed attachments", composeFailedAttachmentsSection(bundle.failedAttachments)],
+  ];
+
+  return sections.map(([title, body]) => `${title}\n${body}`).join("\n\n");
+}
+
+function composeCaptionSection(caption?: string | null): string {
+  const normalizedCaption = caption?.trim();
+
+  if (!normalizedCaption) {
+    return DEFAULT_REQUEST;
+  }
+
+  return normalizedCaption;
+}
+
+function composeAttachmentsSection(attachments: TelegramMessageAttachment[]): string {
+  if (attachments.length === 0) {
+    return "None";
+  }
+
+  return attachments
+    .map((attachment, index) => {
+      const lines = [
+        `${index + 1}. [${attachment.kind}] ${attachment.name}`,
+        `Path: ${attachment.path}`,
+      ];
+
+      if (attachment.mimeType) {
+        lines.push(`MIME type: ${attachment.mimeType}`);
+      }
+
+      if (attachment.sizeBytes != null) {
+        lines.push(`Size: ${attachment.sizeBytes} bytes`);
+      }
+
+      return lines.join("\n");
+    })
+    .join("\n");
+}
+
+function composeFailedAttachmentsSection(failedAttachments: TelegramFailedAttachment[]): string {
+  if (failedAttachments.length === 0) {
+    return "None";
+  }
+
+  return failedAttachments
+    .map((attachment, index) => `${index + 1}. ${attachment.name} - ${attachment.reason}`)
+    .join("\n");
+}
+
+async function saveAttachment(
+  bundleDir: string,
+  index: number,
+  attachment: TelegramMessageAttachmentInput,
+): Promise<TelegramMessageAttachment> {
+  if (attachment.kind === "document") {
+    return saveDocumentAttachment(bundleDir, index, attachment);
+  }
+
+  return savePhotoAttachment(bundleDir, index, attachment);
+}
+
+async function saveDocumentAttachment(
+  bundleDir: string,
+  index: number,
+  attachment: TelegramDocumentAttachmentInput,
+): Promise<TelegramMessageAttachment> {
+  const bytes = toUint8Array(attachment.bytes);
+  const sanitizedName = sanitizeTelegramAttachmentName(attachment.name, "document.bin");
+  const filePath = path.join(bundleDir, buildStoredFilename(index, sanitizedName));
+
+  await writeFile(filePath, bytes);
+
+  return {
+    kind: "document",
+    name: sanitizedName,
+    path: filePath,
+    mimeType: attachment.mimeType ?? null,
+    sizeBytes: bytes.byteLength,
+  };
+}
+
+async function savePhotoAttachment(
+  bundleDir: string,
+  index: number,
+  attachment: TelegramPhotoAttachmentInput,
+): Promise<TelegramMessageAttachment> {
+  const largestVariant = pickLargestPhotoVariant(attachment.variants);
+
+  if (!largestVariant) {
+    throw new Error("photo has no variants");
+  }
+
+  const bytes = toUint8Array(largestVariant.bytes);
+  const sanitizedName = sanitizeTelegramAttachmentName(attachment.name, "photo.jpg");
+  const filePath = path.join(bundleDir, buildStoredFilename(index, sanitizedName));
+
+  await writeFile(filePath, bytes);
+
+  return {
+    kind: "photo",
+    name: sanitizedName,
+    path: filePath,
+    mimeType: largestVariant.mimeType ?? null,
+    sizeBytes: bytes.byteLength,
+  };
+}
+
+function pickLargestPhotoVariant(
+  variants: TelegramPhotoVariantInput[],
+): TelegramPhotoVariantInput | null {
+  if (variants.length === 0) {
+    return null;
+  }
+
+  return variants.reduce((largest, current) =>
+    current.width * current.height > largest.width * largest.height ? current : largest,
+  );
+}
+
+export function sanitizeTelegramAttachmentName(name: string, fallbackName: string): string {
+  const safeName = path
+    .posix
+    .basename(name.replaceAll("\\", "/"))
+    .replace(CONTROL_CHARACTER_PATTERN, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (
+    safeName.length === 0 ||
+    safeName === "." ||
+    safeName === ".." ||
+    safeName.replace(/[.\s]+/g, "").length === 0
+  ) {
+    return fallbackName;
+  }
+
+  return safeName;
+}
+
+function buildStoredFilename(index: number, safeName: string): string {
+  return `${index + 1}-${safeName}`;
+}
+
+function toUint8Array(bytes: TelegramAttachmentBytes): Uint8Array {
+  return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+}
+
+function getFailureReason(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown error";
+}

--- a/src/runtime/create-runtime-deps.ts
+++ b/src/runtime/create-runtime-deps.ts
@@ -1,4 +1,11 @@
 import type { CreateBotHandlersDeps } from "../bot/create-bot";
+import type { TelegramMessageBundle } from "../files/telegram-message-bundle";
+import {
+  composeTelegramMessageBundlePrompt,
+  sanitizeTelegramAttachmentName,
+  saveTelegramMessageBundle,
+  writeTelegramMessageBundleJson,
+} from "../files/telegram-message-bundle";
 import { formatStatusMessage } from "../bot/formatters";
 import type { AppConfig } from "../config";
 import { createCronRuntime } from "../cron/runtime";
@@ -128,11 +135,44 @@ export function createRuntimeDeps(
     cronRuntime.stop();
     cronStarted = false;
   };
+  const prepareAttachmentPrompt: NonNullable<CreateBotHandlersDeps["prepareAttachmentPrompt"]> =
+    async (input) => {
+      const savedBundle = await saveTelegramMessageBundle({
+        workspaceDir: config.workspaceDir,
+        chatId: input.chatId,
+        messageId: input.messageId,
+        caption: input.caption,
+        attachments: input.attachments,
+      });
+      const failedAttachments = [
+        ...savedBundle.bundle.failedAttachments,
+        ...input.failedAttachments.map((attachment) => ({
+          ...attachment,
+          name: sanitizeTelegramAttachmentName(attachment.name, "attachment"),
+        })),
+      ];
+      const mergedBundle: TelegramMessageBundle =
+        failedAttachments.length === savedBundle.bundle.failedAttachments.length
+          ? savedBundle.bundle
+          : {
+              ...savedBundle.bundle,
+              failedAttachments,
+            };
+
+      if (mergedBundle !== savedBundle.bundle) {
+        await writeTelegramMessageBundleJson(savedBundle.bundleJsonPath, mergedBundle);
+      }
+
+      return {
+        prompt: composeTelegramMessageBundlePrompt(mergedBundle),
+      };
+    };
 
   return {
     getStatusMessage: async (chatId) => formatStatusMessage(await runtime.getSession(chatId)),
     resetSession: async (chatId) => runtime.resetSession(chatId),
     abortRun: async (chatId) => runtime.abortRun(chatId),
+    prepareAttachmentPrompt,
     runTurn: async (chatId, prompt) => runtime.runTurn(chatId, prompt),
     startBackgroundServices: startCronRuntime,
     stopBackgroundServices: stopCronRuntime,

--- a/src/runtime/workspace.ts
+++ b/src/runtime/workspace.ts
@@ -18,7 +18,7 @@ export async function ensureWorkspaceDirectories(
   } = {},
 ): Promise<void> {
   await Promise.all(
-    [workspaceDir, path.join(workspaceDir, "state"), path.join(workspaceDir, "logs")].map(
+    [workspaceDir, path.join(workspaceDir, "state"), path.join(workspaceDir, "logs"), path.join(workspaceDir, "inbox")].map(
       (directory) => mkdir(directory, { recursive: true }),
     ),
   );

--- a/tests/integration/create-bot.test.ts
+++ b/tests/integration/create-bot.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, mock, test } from "bun:test";
-import { createBotHandlers } from "../../src/bot/create-bot";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { createBotHandlers, registerBotHandlers } from "../../src/bot/create-bot";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
 
 describe("createBotHandlers", () => {
   test("routes /status to the formatter and normal text to the runtime", async () => {
@@ -176,4 +182,576 @@ describe("createBotHandlers", () => {
 
     expect(events).toEqual(["start", "stop", "reply:done"]);
   });
+
+  test("stops typing before replying on attachment success", async () => {
+    const events: string[] = [];
+    const handlers = createBotHandlers({
+      getStatusMessage: mock(async () => "idle"),
+      resetSession: mock(async () => ({ ok: true as const })),
+      abortRun: mock(async () => ({ ok: false as const, reason: "not-running" as const })),
+      prepareAttachmentPrompt: mock(async () => ({ prompt: "attachment prompt" })),
+      runTurn: mock(async () => ({ summary: "done" })),
+    });
+
+    await handlers.onAttachmentMessage({
+      chatId: 123n,
+      messageId: 16,
+      caption: "review attachment",
+      attachments: [
+        {
+          kind: "document",
+          name: "report.txt",
+          download: async () => new TextEncoder().encode("body"),
+        },
+      ],
+      startTyping: async () => {
+        events.push("start");
+
+        return async () => {
+          events.push("stop");
+        };
+      },
+      reply: async (value: string) => {
+        events.push(`reply:${value}`);
+      },
+    });
+
+    expect(events).toEqual(["start", "stop", "reply:done"]);
+  });
+
+  test("document + caption triggers one runTurn with the prepared prompt", async () => {
+    const replies: string[] = [];
+    const prepareAttachmentPrompt = mock(
+      async (_input: {
+        chatId: number;
+        messageId: number;
+        caption?: string | null;
+        attachments: unknown[];
+        failedAttachments: unknown[];
+      }) => ({ prompt: "document prompt" }),
+    );
+    const runTurn = mock(async (_chatId: bigint, _prompt: string) => ({ summary: "done" }));
+    const handlers = createBotHandlers({
+      getStatusMessage: mock(async () => "idle"),
+      resetSession: mock(async () => ({ ok: true as const })),
+      abortRun: mock(async () => ({ ok: false as const, reason: "not-running" as const })),
+      prepareAttachmentPrompt,
+      runTurn,
+    });
+
+    await handlers.onAttachmentMessage({
+      chatId: 123n,
+      messageId: 10,
+      caption: "please review",
+      attachments: [
+        {
+          kind: "document",
+          name: "report.txt",
+          mimeType: "text/plain",
+          download: async () => new TextEncoder().encode("document body"),
+        },
+      ],
+      reply: async (value: string) => {
+        replies.push(value);
+      },
+    });
+
+    expect(prepareAttachmentPrompt).toHaveBeenCalledTimes(1);
+    expect(prepareAttachmentPrompt).toHaveBeenCalledWith({
+      chatId: 123,
+      messageId: 10,
+      caption: "please review",
+      attachments: [
+        {
+          kind: "document",
+          name: "report.txt",
+          mimeType: "text/plain",
+          bytes: new TextEncoder().encode("document body"),
+        },
+      ],
+      failedAttachments: [],
+    });
+    expect(runTurn).toHaveBeenCalledTimes(1);
+    expect(runTurn).toHaveBeenCalledWith(123n, "document prompt");
+    expect(replies).toEqual(["done"]);
+  });
+
+  test("photo + caption triggers one runTurn with only the largest variant", async () => {
+    const prepareAttachmentPrompt = mock(
+      async (_input: {
+        chatId: number;
+        messageId: number;
+        caption?: string | null;
+        attachments: unknown[];
+        failedAttachments: unknown[];
+      }) => ({ prompt: "photo prompt" }),
+    );
+    const runTurn = mock(async (_chatId: bigint, _prompt: string) => ({ summary: "done" }));
+    const handlers = createBotHandlers({
+      getStatusMessage: mock(async () => "idle"),
+      resetSession: mock(async () => ({ ok: true as const })),
+      abortRun: mock(async () => ({ ok: false as const, reason: "not-running" as const })),
+      prepareAttachmentPrompt,
+      runTurn,
+    });
+
+    await handlers.onAttachmentMessage({
+      chatId: 123n,
+      messageId: 11,
+      caption: "inspect photo",
+      attachments: [
+        {
+          kind: "photo",
+          name: "telegram-photo.jpg",
+          variants: [
+            {
+              name: "small.jpg",
+              width: 320,
+              height: 200,
+              mimeType: "image/jpeg",
+              download: async () => new TextEncoder().encode("small"),
+            },
+            {
+              name: "large.jpg",
+              width: 1280,
+              height: 720,
+              mimeType: "image/jpeg",
+              download: async () => new TextEncoder().encode("large"),
+            },
+          ],
+        },
+      ],
+      reply: async () => undefined,
+    });
+
+    expect(prepareAttachmentPrompt).toHaveBeenCalledTimes(1);
+    expect(prepareAttachmentPrompt).toHaveBeenCalledWith({
+      chatId: 123,
+      messageId: 11,
+      caption: "inspect photo",
+      attachments: [
+        {
+          kind: "photo",
+          name: "telegram-photo.jpg",
+          variants: [
+            {
+              name: "large.jpg",
+              width: 1280,
+              height: 720,
+              mimeType: "image/jpeg",
+              bytes: new TextEncoder().encode("large"),
+            },
+          ],
+        },
+      ],
+      failedAttachments: [],
+    });
+    expect(runTurn).toHaveBeenCalledTimes(1);
+    expect(runTurn).toHaveBeenCalledWith(123n, "photo prompt");
+  });
+
+  test("calls runTurn even when partial attachment failure metadata is present", async () => {
+    const prepareAttachmentPrompt = mock(
+      async (_input: {
+        chatId: number;
+        messageId: number;
+        caption?: string | null;
+        attachments: unknown[];
+        failedAttachments: { name: string; reason: string }[];
+      }) => ({ prompt: "mixed prompt" }),
+    );
+    const runTurn = mock(async (_chatId: bigint, _prompt: string) => ({ summary: "done" }));
+    const handlers = createBotHandlers({
+      getStatusMessage: mock(async () => "idle"),
+      resetSession: mock(async () => ({ ok: true as const })),
+      abortRun: mock(async () => ({ ok: false as const, reason: "not-running" as const })),
+      prepareAttachmentPrompt,
+      runTurn,
+    });
+
+    await handlers.onAttachmentMessage({
+      chatId: 123n,
+      messageId: 12,
+      caption: "mixed upload",
+      attachments: [
+        {
+          kind: "document",
+          name: "ok.txt",
+          download: async () => new TextEncoder().encode("ok"),
+        },
+        {
+          kind: "document",
+          name: "broken.txt",
+          download: async () => {
+            throw new Error("download failed");
+          },
+        },
+      ],
+      reply: async () => undefined,
+    });
+
+    expect(prepareAttachmentPrompt).toHaveBeenCalledTimes(1);
+    expect(prepareAttachmentPrompt.mock.calls[0]?.[0]).toEqual({
+      chatId: 123,
+      messageId: 12,
+      caption: "mixed upload",
+      attachments: [
+        {
+          kind: "document",
+          name: "ok.txt",
+          bytes: new TextEncoder().encode("ok"),
+        },
+      ],
+      failedAttachments: [{ name: "broken.txt", reason: "download failed" }],
+    });
+    expect(runTurn).toHaveBeenCalledTimes(1);
+    expect(runTurn).toHaveBeenCalledWith(123n, "mixed prompt");
+  });
+
+  test("calls runTurn when all attachments failed but a caption exists", async () => {
+    const prepareAttachmentPrompt = mock(
+      async (_input: {
+        chatId: number;
+        messageId: number;
+        caption?: string | null;
+        attachments: unknown[];
+        failedAttachments: { name: string; reason: string }[];
+      }) => ({ prompt: "caption-only prompt" }),
+    );
+    const runTurn = mock(async (_chatId: bigint, _prompt: string) => ({ summary: "done" }));
+    const handlers = createBotHandlers({
+      getStatusMessage: mock(async () => "idle"),
+      resetSession: mock(async () => ({ ok: true as const })),
+      abortRun: mock(async () => ({ ok: false as const, reason: "not-running" as const })),
+      prepareAttachmentPrompt,
+      runTurn,
+    });
+
+    await handlers.onAttachmentMessage({
+      chatId: 123n,
+      messageId: 13,
+      caption: "still continue",
+      attachments: [
+        {
+          kind: "document",
+          name: "broken.txt",
+          download: async () => {
+            throw new Error("download failed");
+          },
+        },
+      ],
+      reply: async () => undefined,
+    });
+
+    expect(prepareAttachmentPrompt).toHaveBeenCalledTimes(1);
+    expect(prepareAttachmentPrompt).toHaveBeenCalledWith({
+      chatId: 123,
+      messageId: 13,
+      caption: "still continue",
+      attachments: [],
+      failedAttachments: [{ name: "broken.txt", reason: "download failed" }],
+    });
+    expect(runTurn).toHaveBeenCalledTimes(1);
+    expect(runTurn).toHaveBeenCalledWith(123n, "caption-only prompt");
+  });
+
+  test("replies with a failure and skips runTurn when bundle preparation throws", async () => {
+    const replies: string[] = [];
+    const prepareAttachmentPrompt = mock(async (_input: {
+      chatId: number;
+      messageId: number;
+      caption?: string | null;
+      attachments: unknown[];
+      failedAttachments: unknown[];
+    }) => {
+      throw new Error("disk full");
+    });
+    const runTurn = mock(async (_chatId: bigint, _prompt: string) => ({ summary: "done" }));
+    const handlers = createBotHandlers({
+      getStatusMessage: mock(async () => "idle"),
+      resetSession: mock(async () => ({ ok: true as const })),
+      abortRun: mock(async () => ({ ok: false as const, reason: "not-running" as const })),
+      prepareAttachmentPrompt,
+      runTurn,
+    });
+
+    await handlers.onAttachmentMessage({
+      chatId: 123n,
+      messageId: 14,
+      caption: "please retry",
+      attachments: [
+        {
+          kind: "document",
+          name: "report.txt",
+          download: async () => new TextEncoder().encode("body"),
+        },
+      ],
+      reply: async (value: string) => {
+        replies.push(value);
+      },
+    });
+
+    expect(prepareAttachmentPrompt).toHaveBeenCalledTimes(1);
+    expect(runTurn).not.toHaveBeenCalled();
+    expect(replies).toEqual(["Failed to prepare attachment bundle: disk full"]);
+  });
+
+  test("does not re-inject attachment context into a later plain text follow-up", async () => {
+    const prepareAttachmentPrompt = mock(
+      async (_input: {
+        chatId: number;
+        messageId: number;
+        caption?: string | null;
+        attachments: unknown[];
+        failedAttachments: unknown[];
+      }) => ({ prompt: "bundle prompt" }),
+    );
+    const runTurn = mock(async (_chatId: bigint, _prompt: string) => ({ summary: "done" }));
+    const handlers = createBotHandlers({
+      getStatusMessage: mock(async () => "idle"),
+      resetSession: mock(async () => ({ ok: true as const })),
+      abortRun: mock(async () => ({ ok: false as const, reason: "not-running" as const })),
+      prepareAttachmentPrompt,
+      runTurn,
+    });
+
+    await handlers.onAttachmentMessage({
+      chatId: 123n,
+      messageId: 15,
+      caption: "review this",
+      attachments: [
+        {
+          kind: "document",
+          name: "report.txt",
+          download: async () => new TextEncoder().encode("body"),
+        },
+      ],
+      reply: async () => undefined,
+    });
+
+    await handlers.onText({
+      chatId: 123n,
+      text: "follow up question",
+      reply: async () => undefined,
+    });
+
+    expect(prepareAttachmentPrompt).toHaveBeenCalledTimes(1);
+    expect(runTurn).toHaveBeenCalledTimes(2);
+    expect(runTurn.mock.calls[0]).toEqual([123n, "bundle prompt"]);
+    expect(runTurn.mock.calls[1]).toEqual([123n, "follow up question"]);
+  });
 });
+
+describe("registerBotHandlers", () => {
+  test("coalesces a photo media group into one prepared prompt", async () => {
+    const listeners = new Map<string, (ctx: any) => Promise<void>>();
+    const prepareAttachmentPrompt = mock(async (input) => {
+      expect(input.caption).toBe("album caption");
+      expect(input.attachments).toHaveLength(2);
+      expect(input.attachments[0]?.kind).toBe("photo");
+      expect(input.attachments[1]?.kind).toBe("photo");
+
+      return { prompt: "album prompt" };
+    });
+    const runTurn = mock(async () => ({ summary: "done" }));
+    const timers: Array<() => void> = [];
+    const activeTimers = new Set<number>();
+    const bot = {
+      token: "telegram-token",
+      on(event: string, handler: (ctx: any) => Promise<void>) {
+        listeners.set(event, handler);
+        return this;
+      },
+    } as any;
+
+    globalThis.fetch = mock(async (url: string | URL | Request) => ({
+      ok: true,
+      arrayBuffer: async () =>
+        new TextEncoder().encode(String(url).includes("file-1") ? "photo-1" : "photo-2").buffer,
+    })) as unknown as typeof fetch;
+
+    registerBotHandlers(
+      bot,
+      {
+        getStatusMessage: mock(async () => "idle"),
+        resetSession: mock(async () => ({ ok: true as const })),
+        abortRun: mock(async () => ({ ok: false as const, reason: "not-running" as const })),
+        prepareAttachmentPrompt,
+        runTurn,
+      },
+      {
+        mediaGroupDebounceMs: 0,
+        setTimeoutFn: (callback) => {
+          const id = timers.push(callback) - 1;
+          activeTimers.add(id);
+          return id as unknown as ReturnType<typeof setTimeout>;
+        },
+        clearTimeoutFn: (handle) => {
+          activeTimers.delete(Number(handle));
+        },
+      },
+    );
+
+    const onPhoto = listeners.get("message:photo");
+    expect(onPhoto).toBeDefined();
+
+    await onPhoto?.(createPhotoContext({
+      messageId: 20,
+      mediaGroupId: "album-1",
+      caption: "album caption",
+      fileId: "file-1",
+      fileUniqueId: "unique-1",
+    }));
+    await onPhoto?.(createPhotoContext({
+      messageId: 21,
+      mediaGroupId: "album-1",
+      fileId: "file-2",
+      fileUniqueId: "unique-2",
+    }));
+
+    expect(prepareAttachmentPrompt).toHaveBeenCalledTimes(0);
+    expect(runTurn).toHaveBeenCalledTimes(0);
+
+    for (const [id, callback] of timers.entries()) {
+      if (activeTimers.has(id)) {
+        callback();
+      }
+    }
+
+    await flushAsyncWork();
+
+    expect(prepareAttachmentPrompt).toHaveBeenCalledTimes(1);
+    expect(runTurn).toHaveBeenCalledTimes(1);
+    expect(runTurn).toHaveBeenCalledWith(123n, "album prompt");
+  });
+
+  test("passes download failures through failedAttachments for document messages", async () => {
+    const listeners = new Map<string, (ctx: any) => Promise<void>>();
+    const prepareAttachmentPrompt = mock(async (input) => {
+      expect(input.attachments).toEqual([]);
+      expect(input.failedAttachments).toEqual([
+        {
+          name: "broken.json",
+          reason: "telegram file path missing",
+        },
+      ]);
+
+      return { prompt: "failed download prompt" };
+    });
+    const runTurn = mock(async () => ({ summary: "done" }));
+    const replies: string[] = [];
+    const bot = {
+      token: "telegram-token",
+      on(event: string, handler: (ctx: any) => Promise<void>) {
+        listeners.set(event, handler);
+        return this;
+      },
+    } as any;
+
+    registerBotHandlers(bot, {
+      getStatusMessage: mock(async () => "idle"),
+      resetSession: mock(async () => ({ ok: true as const })),
+      abortRun: mock(async () => ({ ok: false as const, reason: "not-running" as const })),
+      prepareAttachmentPrompt,
+      runTurn,
+    });
+
+    const onDocument = listeners.get("message:document");
+    expect(onDocument).toBeDefined();
+
+    await onDocument?.(createDocumentContext({
+      messageId: 30,
+      caption: "keep going",
+      fileName: "broken.json",
+      fileId: "broken-file",
+      reply: async (value: string) => {
+        replies.push(value);
+      },
+      apiGetFile: async () => ({}),
+    }));
+
+    expect(prepareAttachmentPrompt).toHaveBeenCalledTimes(1);
+    expect(runTurn).toHaveBeenCalledTimes(1);
+    expect(runTurn).toHaveBeenCalledWith(123n, "failed download prompt");
+    expect(replies).toEqual(["done"]);
+  });
+});
+
+function createPhotoContext({
+  messageId,
+  mediaGroupId,
+  caption,
+  fileId,
+  fileUniqueId,
+}: {
+  messageId: number;
+  mediaGroupId?: string;
+  caption?: string;
+  fileId: string;
+  fileUniqueId: string;
+}) {
+  return {
+    chat: { id: 123 },
+    message: {
+      message_id: messageId,
+      media_group_id: mediaGroupId,
+      caption,
+      photo: [
+        {
+          file_id: fileId,
+          file_unique_id: fileUniqueId,
+          width: 640,
+          height: 480,
+        },
+      ],
+    },
+    api: {
+      getFile: async (requestedFileId: string) => ({
+        file_path: `photos/${requestedFileId}.jpg`,
+      }),
+    },
+    replyWithChatAction: async () => undefined,
+    reply: async () => undefined,
+  };
+}
+
+function createDocumentContext({
+  messageId,
+  caption,
+  fileName,
+  fileId,
+  reply,
+  apiGetFile,
+}: {
+  messageId: number;
+  caption?: string;
+  fileName: string;
+  fileId: string;
+  reply: (value: string) => Promise<void>;
+  apiGetFile: (fileId: string) => Promise<Record<string, unknown>>;
+}) {
+  return {
+    chat: { id: 123 },
+    message: {
+      message_id: messageId,
+      caption,
+      document: {
+        file_id: fileId,
+        file_unique_id: "document-unique",
+        file_name: fileName,
+        mime_type: "application/json",
+      },
+    },
+    api: {
+      getFile: apiGetFile,
+    },
+    replyWithChatAction: async () => undefined,
+    reply,
+  };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Bun.sleep(0);
+}

--- a/tests/integration/cron-loader.test.ts
+++ b/tests/integration/cron-loader.test.ts
@@ -84,6 +84,89 @@ describe("createCronRuntime loading", () => {
 });
 
 describe("createRuntimeDeps cron wiring", () => {
+  test("persists merged failed attachment metadata back into bundle.json", async () => {
+    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "codex-claw-runtime-deps-"));
+
+    try {
+      const deps = createRuntimeDeps(
+        {
+          telegramBotToken: null,
+          openAiApiKey: null,
+          workspaceDir,
+        },
+        {
+          createSdkRuntimeClientFn: () => ({
+            runTurn: mock(async () => ({
+              threadId: "thread_1",
+              summary: "done",
+              touchedPaths: [],
+            })),
+          }),
+          createCronRuntimeFn: () => ({
+            syncNow: mock(async () => ({
+              registered: [],
+              skippedDisabled: [],
+              errors: [],
+            })),
+            refresh: mock(async () => ({
+              registered: [],
+              skippedDisabled: [],
+              errors: [],
+            })),
+            tick: mock(async () => ({
+              registered: [],
+              skippedDisabled: [],
+              errors: [],
+            })),
+            start: mock(async () => ({
+              registered: [],
+              skippedDisabled: [],
+              errors: [],
+            })),
+            stop: mock(() => undefined),
+            getRegisteredJobIds: mock(() => []),
+          }),
+        },
+      );
+
+      const prepared = await deps.prepareAttachmentPrompt?.({
+        chatId: 321,
+        messageId: 654,
+        caption: "review this upload",
+        attachments: [
+          {
+            kind: "document",
+            name: "report.txt",
+            bytes: new TextEncoder().encode("document body"),
+          },
+        ],
+        failedAttachments: [
+          {
+            name: "remote\nbroken.txt",
+            reason: "download failed",
+          },
+        ],
+      });
+
+      expect(prepared?.prompt).toContain("remote broken.txt - download failed");
+
+      const bundle = JSON.parse(
+        readFileSync(path.join(workspaceDir, "inbox", "321", "654", "bundle.json"), "utf8"),
+      ) as {
+        failedAttachments: { name: string; reason: string }[];
+      };
+
+      expect(bundle.failedAttachments).toEqual([
+        {
+          name: "remote broken.txt",
+          reason: "download failed",
+        },
+      ]);
+    } finally {
+      rmSync(workspaceDir, { force: true, recursive: true });
+    }
+  });
+
   test("runs a real cron runtime through createRuntimeDeps with an isolated codex home", async () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "codex-claw-runtime-deps-e2e-"));
     const workspaceDir = path.join(root, "workspace");

--- a/tests/smoke/readme.test.ts
+++ b/tests/smoke/readme.test.ts
@@ -12,6 +12,15 @@ describe("README", () => {
     expect(readme).toContain("입력하세요");
     expect(readme).toContain("codex-claw-agentty");
     expect(readme).toContain("npx -y agentty-cli");
+    expect(readme).toContain("## Telegram Attachments");
+    expect(readme).toContain("Supported attachment types: `document`, `photo`");
+    expect(readme).toContain("one Telegram attachment message as one Codex turn");
+    expect(readme).toContain("~/.codex-claw/workspace/inbox/<chatId>/<messageId>/");
+    expect(readme).toContain("bundle.json");
+    expect(readme).toContain("largest Telegram photo variant");
+    expect(readme).toContain("media_group_id");
+    expect(readme).toContain("failedAttachments");
+    expect(readme).toContain("there is no automatic deletion yet");
     expect(readme).toContain("/status");
     expect(readme).toContain("/reset");
     expect(readme).toContain("/abort");

--- a/tests/unit/runtime-workspace.test.ts
+++ b/tests/unit/runtime-workspace.test.ts
@@ -181,6 +181,7 @@ describe("ensureWorkspaceDirectories", () => {
       expect(statSync(path.join(workspaceDir, "workspace")).isDirectory()).toBe(true);
       expect(statSync(path.join(workspaceDir, "workspace", "state")).isDirectory()).toBe(true);
       expect(statSync(path.join(workspaceDir, "workspace", "logs")).isDirectory()).toBe(true);
+      expect(statSync(path.join(workspaceDir, "workspace", "inbox")).isDirectory()).toBe(true);
       expect(installCronjobCreatorSkill).toHaveBeenCalledTimes(1);
       expect(installAgenttySkill).toHaveBeenCalledTimes(1);
     } finally {

--- a/tests/unit/telegram-message-bundle.test.ts
+++ b/tests/unit/telegram-message-bundle.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  composeTelegramMessageBundlePrompt,
+  getTelegramMessageBundleDirectory,
+  saveTelegramMessageBundle,
+  type TelegramFailedAttachment,
+  type TelegramMessageAttachment,
+  type TelegramMessageBundle,
+} from "../../src/files/telegram-message-bundle";
+
+function createAttachment(overrides?: Partial<TelegramMessageAttachment>): TelegramMessageAttachment {
+  return {
+    kind: "document",
+    name: "report.json",
+    path: "/tmp/report.json",
+    mimeType: "application/json",
+    sizeBytes: 128,
+    ...overrides,
+  };
+}
+
+function createFailedAttachment(
+  overrides?: Partial<TelegramFailedAttachment>,
+): TelegramFailedAttachment {
+  return {
+    name: "broken.png",
+    reason: "download failed",
+    ...overrides,
+  };
+}
+
+function createBundle(overrides?: Partial<TelegramMessageBundle>): TelegramMessageBundle {
+  return {
+    chatId: 100,
+    messageId: 200,
+    caption: "이 파일 검토해줘",
+    attachments: [createAttachment()],
+    failedAttachments: [],
+    ...overrides,
+  };
+}
+
+describe("composeTelegramMessageBundlePrompt", () => {
+  test("uses the caption as the main request and lists attachments in a structured block", () => {
+    const prompt = composeTelegramMessageBundlePrompt(createBundle());
+
+    expect(prompt).toContain("User caption");
+    expect(prompt).toContain("이 파일 검토해줘");
+    expect(prompt).toContain("Attachments");
+    expect(prompt).toContain("1. [document] report.json");
+    expect(prompt).toContain("Path: /tmp/report.json");
+    expect(prompt).toContain("MIME type: application/json");
+    expect(prompt).toContain("Size: 128 bytes");
+  });
+
+  test("lists failed attachments separately with name and reason", () => {
+    const prompt = composeTelegramMessageBundlePrompt(
+      createBundle({
+        failedAttachments: [createFailedAttachment()],
+      }),
+    );
+
+    expect(prompt).toContain("Failed attachments");
+    expect(prompt).toContain("1. broken.png - download failed");
+  });
+
+  test("uses a short default request when the caption is absent", () => {
+    const prompt = composeTelegramMessageBundlePrompt(
+      createBundle({
+        caption: null,
+        attachments: [
+          createAttachment({
+            kind: "photo",
+            name: "telegram-photo.jpg",
+            path: "/tmp/photo.jpg",
+            mimeType: "image/jpeg",
+          }),
+        ],
+      }),
+    );
+
+    expect(prompt).toContain("User caption");
+    expect(prompt).toContain(
+      "The user uploaded Telegram attachments. Review the saved files and continue with the appropriate next step.",
+    );
+    expect(prompt).toContain("1. [photo] telegram-photo.jpg");
+  });
+
+  test("always includes all required sections even when lists are empty", () => {
+    const prompt = composeTelegramMessageBundlePrompt(
+      createBundle({
+        attachments: [],
+        failedAttachments: [],
+      }),
+    );
+
+    expect(prompt).toContain("User caption");
+    expect(prompt).toContain("Attachments");
+    expect(prompt).toContain("Failed attachments");
+    expect(prompt).toContain("None");
+  });
+});
+
+describe("getTelegramMessageBundleDirectory", () => {
+  test("uses the inbox/chat/message path shape", () => {
+    expect(getTelegramMessageBundleDirectory("/tmp/workspace", 777, 888)).toBe(
+      path.join("/tmp/workspace", "inbox", "777", "888"),
+    );
+  });
+});
+
+describe("saveTelegramMessageBundle", () => {
+  test("writes bundle.json and document attachments into the message bundle directory", async () => {
+    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "codex-claw-telegram-bundle-"));
+
+    try {
+      const result = await saveTelegramMessageBundle({
+        workspaceDir,
+        chatId: 42,
+        messageId: 99,
+        caption: "please review",
+        attachments: [
+          {
+            kind: "document",
+            name: "report.txt",
+            mimeType: "text/plain",
+            bytes: new TextEncoder().encode("document body"),
+          },
+        ],
+      });
+
+      expect(result.bundleDir).toBe(path.join(workspaceDir, "inbox", "42", "99"));
+      expect(statSync(result.bundleDir).isDirectory()).toBe(true);
+      expect(result.bundle.attachments).toHaveLength(1);
+      expect(result.bundle.failedAttachments).toHaveLength(0);
+
+      const savedAttachment = result.bundle.attachments[0];
+      expect(savedAttachment?.name).toBe("report.txt");
+      expect(savedAttachment?.kind).toBe("document");
+      expect(readFileSync(savedAttachment!.path, "utf8")).toBe("document body");
+
+      const savedBundle = JSON.parse(
+        readFileSync(path.join(result.bundleDir, "bundle.json"), "utf8"),
+      ) as TelegramMessageBundle;
+
+      expect(savedBundle.messageId).toBe(99);
+      expect(savedBundle.caption).toBe("please review");
+      expect(savedBundle.attachments).toHaveLength(1);
+      expect(savedBundle.failedAttachments).toHaveLength(0);
+    } finally {
+      rmSync(workspaceDir, { force: true, recursive: true });
+    }
+  });
+
+  test("stores only the largest photo resolution for a photo attachment", async () => {
+    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "codex-claw-telegram-bundle-"));
+
+    try {
+      const result = await saveTelegramMessageBundle({
+        workspaceDir,
+        chatId: 7,
+        messageId: 8,
+        attachments: [
+          {
+            kind: "photo",
+            name: "telegram-photo.jpg",
+            variants: [
+              {
+                name: "small.jpg",
+                width: 320,
+                height: 200,
+                bytes: new TextEncoder().encode("small"),
+                mimeType: "image/jpeg",
+              },
+              {
+                name: "large.jpg",
+                width: 1280,
+                height: 720,
+                bytes: new TextEncoder().encode("large"),
+                mimeType: "image/jpeg",
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.bundle.attachments).toHaveLength(1);
+      expect(result.bundle.failedAttachments).toHaveLength(0);
+      expect(result.bundle.attachments[0]?.name).toBe("telegram-photo.jpg");
+      expect(result.bundle.attachments[0]?.kind).toBe("photo");
+      expect(readFileSync(result.bundle.attachments[0]!.path, "utf8")).toBe("large");
+    } finally {
+      rmSync(workspaceDir, { force: true, recursive: true });
+    }
+  });
+
+  test("keeps successful files and records failure metadata when some attachments cannot be stored", async () => {
+    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "codex-claw-telegram-bundle-"));
+
+    try {
+      const result = await saveTelegramMessageBundle({
+        workspaceDir,
+        chatId: 10,
+        messageId: 11,
+        caption: "mixed upload",
+        attachments: [
+          {
+            kind: "document",
+            name: "ok.txt",
+            bytes: new TextEncoder().encode("ok"),
+          },
+          {
+            kind: "photo",
+            name: "broken-photo.jpg",
+            variants: [],
+          },
+        ],
+      });
+
+      expect(result.bundle.attachments).toHaveLength(1);
+      expect(result.bundle.failedAttachments).toEqual([
+        {
+          name: "broken-photo.jpg",
+          reason: "photo has no variants",
+        },
+      ]);
+      expect(readFileSync(result.bundle.attachments[0]!.path, "utf8")).toBe("ok");
+
+      const savedBundle = JSON.parse(
+        readFileSync(path.join(result.bundleDir, "bundle.json"), "utf8"),
+      ) as TelegramMessageBundle;
+
+      expect(savedBundle.attachments).toHaveLength(1);
+      expect(savedBundle.failedAttachments).toEqual([
+        {
+          name: "broken-photo.jpg",
+          reason: "photo has no variants",
+        },
+      ]);
+    } finally {
+      rmSync(workspaceDir, { force: true, recursive: true });
+    }
+  });
+
+  test("sanitizes stored filenames and metadata names derived from attachment names", async () => {
+    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "codex-claw-telegram-bundle-"));
+
+    try {
+      const result = await saveTelegramMessageBundle({
+        workspaceDir,
+        chatId: 12,
+        messageId: 13,
+        attachments: [
+          {
+            kind: "document",
+            name: "bad\nname.txt",
+            bytes: new TextEncoder().encode("document body"),
+          },
+          {
+            kind: "document",
+            name: " \r\n\t ",
+            bytes: new TextEncoder().encode("fallback body"),
+          },
+        ],
+      });
+
+      expect(result.bundle.attachments).toHaveLength(2);
+      expect(result.bundle.attachments[0]?.name).toBe("bad name.txt");
+      expect(path.basename(result.bundle.attachments[0]!.path)).toBe("1-bad name.txt");
+      expect(result.bundle.attachments[1]?.name).toBe("document.bin");
+      expect(path.basename(result.bundle.attachments[1]!.path)).toBe("2-document.bin");
+
+      const savedBundle = JSON.parse(
+        readFileSync(path.join(result.bundleDir, "bundle.json"), "utf8"),
+      ) as TelegramMessageBundle;
+
+      expect(savedBundle.attachments[0]?.name).toBe("bad name.txt");
+      expect(savedBundle.attachments[1]?.name).toBe("document.bin");
+    } finally {
+      rmSync(workspaceDir, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Telegram attachment bundle intake for document and photo messages
- save bundles under ~/.codex-claw/workspace/inbox/<chatId>/<messageId> with bundle.json metadata
- coalesce Telegram photo media groups into a single Codex turn and preserve failed attachment metadata

## Verification
- bun test
- bun run typecheck