### PR TITLE
feat: make Telegram slash-command sync always-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,7 @@ On startup, the CLI also attempts to install packaged skills to:
 Those skills can be used by Codex to create scheduled job definition files and to prefer `npx -y agentty-cli` for interactive CLI login and approval flows.
 The packaged `codex-claw-telegram-file-send` skill lets Codex send one local file to the current active `codex-claw` Telegram chat as a Telegram document.
 
-If you want the CLI to sync the Telegram slash-command menu on startup, enable it explicitly:
-
-```bash
-TELEGRAM_SYNC_COMMANDS=1 bunx @npmc_5/codex-claw
-```
-
-When enabled, the CLI attempts to sync the Telegram slash-command menu so it stays aligned with the commands the bot actually supports. If Telegram rejects that sync request, bot startup still continues and the CLI only logs a warning.
+The CLI attempts to sync the Telegram slash-command menu on startup so it stays aligned with the commands the bot actually supports. If Telegram rejects that sync request, bot startup still continues and the CLI only logs a warning.
 
 ## Telegram Usage
 
@@ -181,7 +175,7 @@ Notes:
 
 Notes:
 
-- The Telegram slash-command menu is only synced when `TELEGRAM_SYNC_COMMANDS=1` is set at startup.
+- The Telegram slash-command menu is synced automatically during startup.
 - `/reset` only succeeds when no run is active.
 - `/abort` is best-effort cancellation for the current in-flight turn.
 - If you send a new message while a run is still active, the runtime rejects the overlapping run.

--- a/docs/plans/2026-03-12-telegram-command-sync-always-on-design.md
+++ b/docs/plans/2026-03-12-telegram-command-sync-always-on-design.md
@@ -1,0 +1,105 @@
+# Telegram Command Sync Always-On Design
+
+**Date:** 2026-03-12
+**Issue:** `#36` feat: make Telegram slash-command sync always-on
+
+## Goal
+
+Telegram slash-command menu synchronization should always be attempted during startup without requiring a feature flag.
+
+## Scope
+
+- Remove the `TELEGRAM_SYNC_COMMANDS` startup gate from runtime configuration.
+- Always call Telegram command synchronization during bot startup.
+- Keep sync failure non-fatal so the bot can continue starting.
+- Update tests and README to match the always-on behavior.
+
+## Non-Goals
+
+- Adding a new opt-out flag
+- Refactoring unrelated startup/runtime wiring
+- Fixing the unrelated baseline test failures already present on `main`
+
+## Current State
+
+- [src/config.ts](/Users/pinion/.config/superpowers/worktrees/codex-claw/feature-telegram-command-sync-always-on/src/config.ts) exposes `syncTelegramCommandsOnStartup`.
+- [src/index.ts](/Users/pinion/.config/superpowers/worktrees/codex-claw/feature-telegram-command-sync-always-on/src/index.ts) only calls Telegram sync when that flag is true.
+- [README.md](/Users/pinion/.config/superpowers/worktrees/codex-claw/feature-telegram-command-sync-always-on/README.md) documents `TELEGRAM_SYNC_COMMANDS=1` as the enable switch.
+
+This makes command menu sync optional, which does not match the desired product behavior of "always keep Telegram command suggestions aligned."
+
+## Approaches Considered
+
+### 1. Remove the flag and always sync at startup
+
+Delete the config field and unconditionalize the existing `syncTelegramCommands(bot)` call.
+
+**Pros**
+- Behavior matches the feature request exactly
+- Lowest long-term maintenance cost
+- Keeps the existing non-blocking failure policy intact
+
+**Cons**
+- Removes the ability to disable sync in edge-case environments
+
+### 2. Keep a hidden internal flag
+
+Document the feature as always-on while preserving an undocumented escape hatch.
+
+**Pros**
+- Easier rollback for maintainers
+
+**Cons**
+- Leaves dead-looking configuration paths behind
+- Violates the explicit request for always-on behavior
+
+### 3. Fold sync into a deeper startup refactor
+
+Move command sync into a larger startup lifecycle abstraction.
+
+**Pros**
+- Could improve startup cohesion later
+
+**Cons**
+- Over-scoped for a small behavior change
+- Increases regression risk
+
+## Recommended Approach
+
+Choose approach 1: remove the flag and always attempt sync at startup.
+
+This keeps the behavior simple: if the bot starts, it also tries to keep the Telegram slash-command menu current. The existing warning-only failure handling already gives enough safety if Telegram rejects the sync request.
+
+## Data Flow
+
+1. App loads runtime configuration.
+2. App creates the Telegram bot instance.
+3. App registers handlers.
+4. App always fires `syncTelegramCommands(bot)` without awaiting startup on it.
+5. Bot startup continues even if sync fails.
+
+## Error Handling
+
+- `setMyCommands` failures remain warning-only.
+- The sync call stays non-blocking relative to `bot.start()`.
+- No new retry logic is introduced.
+
+## Testing Strategy
+
+### Unit
+
+- `loadConfig()` no longer returns a sync flag.
+- Startup always calls `syncTelegramCommands()`.
+- Startup still does not wait on sync completion before starting.
+
+### Docs / Smoke
+
+- README no longer advertises an enable flag.
+- README states that command sync happens on startup.
+
+## Acceptance Criteria
+
+- No runtime config field or env var controls Telegram command sync.
+- Startup always attempts command sync.
+- Startup still succeeds when sync hangs or fails.
+- Documentation reflects the always-on behavior.

--- a/docs/plans/2026-03-12-telegram-command-sync-always-on-design.md
+++ b/docs/plans/2026-03-12-telegram-command-sync-always-on-design.md
@@ -22,9 +22,9 @@ Telegram slash-command menu synchronization should always be attempted during st
 
 ## Current State
 
-- [src/config.ts](/Users/pinion/.config/superpowers/worktrees/codex-claw/feature-telegram-command-sync-always-on/src/config.ts) exposes `syncTelegramCommandsOnStartup`.
-- [src/index.ts](/Users/pinion/.config/superpowers/worktrees/codex-claw/feature-telegram-command-sync-always-on/src/index.ts) only calls Telegram sync when that flag is true.
-- [README.md](/Users/pinion/.config/superpowers/worktrees/codex-claw/feature-telegram-command-sync-always-on/README.md) documents `TELEGRAM_SYNC_COMMANDS=1` as the enable switch.
+- [src/config.ts](../../src/config.ts) exposes `syncTelegramCommandsOnStartup`.
+- [src/index.ts](../../src/index.ts) only calls Telegram sync when that flag is true.
+- [README.md](../../README.md) documents `TELEGRAM_SYNC_COMMANDS=1` as the enable switch.
 
 This makes command menu sync optional, which does not match the desired product behavior of "always keep Telegram command suggestions aligned."
 

--- a/docs/plans/2026-03-12-telegram-command-sync-always-on.md
+++ b/docs/plans/2026-03-12-telegram-command-sync-always-on.md
@@ -1,0 +1,88 @@
+# Telegram Command Sync Always-On Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove the optional startup gate so `codex-claw` always attempts Telegram slash-command sync on startup.
+
+**Architecture:** Delete the config flag, unconditionalize the existing startup sync call, and keep the existing warning-only, non-blocking sync helper behavior. Update focused tests and README to match the new contract without broad startup refactors.
+
+**Tech Stack:** Bun, TypeScript, grammY, Bun test
+
+---
+
+### Task 1: Lock the new startup contract with tests
+
+**Files:**
+- Modify: `tests/unit/config.test.ts`
+- Modify: `tests/unit/index-telegram-command-sync.test.ts`
+
+**Step 1: Write the failing test**
+
+Change the config tests to stop expecting `syncTelegramCommandsOnStartup`, and change the startup tests to expect Telegram command sync to be called by default.
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test tests/unit/config.test.ts tests/unit/index-telegram-command-sync.test.ts`
+Expected: FAIL because the production code still exposes the flag and still skips sync by default.
+
+**Step 3: Write minimal implementation**
+
+Update `src/config.ts` to remove the flag from `AppConfig` and `loadConfig()`, then update `src/index.ts` to always call `syncTelegramCommands(bot)`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test tests/unit/config.test.ts tests/unit/index-telegram-command-sync.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/config.ts src/index.ts tests/unit/config.test.ts tests/unit/index-telegram-command-sync.test.ts
+git commit -m "feat: always sync telegram commands on startup"
+```
+
+### Task 2: Update user-facing docs and README assertions
+
+**Files:**
+- Modify: `README.md`
+- Modify: `tests/smoke/readme.test.ts`
+
+**Step 1: Write the failing test**
+
+Update the README smoke test so it expects always-on startup sync wording and no longer expects `TELEGRAM_SYNC_COMMANDS=1`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test tests/smoke/readme.test.ts`
+Expected: FAIL because the README still describes the old opt-in flow.
+
+**Step 3: Write minimal implementation**
+
+Edit `README.md` to describe Telegram slash-command sync as a default startup behavior.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test tests/smoke/readme.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add README.md tests/smoke/readme.test.ts
+git commit -m "docs: make telegram command sync always-on"
+```
+
+### Task 3: Run focused verification for the changed surface
+
+**Files:**
+- Verify only
+
+**Step 1: Run the focused verification suite**
+
+Run: `bun test tests/unit/config.test.ts tests/unit/index-telegram-command-sync.test.ts tests/smoke/readme.test.ts`
+Expected: PASS
+
+**Step 2: Review diff for unintended scope**
+
+Run: `git status --short && git diff -- src/config.ts src/index.ts README.md tests/unit/config.test.ts tests/unit/index-telegram-command-sync.test.ts tests/smoke/readme.test.ts`
+Expected: Only the planned always-on sync changes are present.

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,6 @@ export type AppConfig = {
   telegramBotToken: string | null;
   openAiApiKey: string | null;
   workspaceDir: string;
-  syncTelegramCommandsOnStartup: boolean;
 };
 
 export function loadConfig(env: Env = process.env): AppConfig {
@@ -14,7 +13,6 @@ export function loadConfig(env: Env = process.env): AppConfig {
     telegramBotToken: normalizeOptionalEnv(env.TELEGRAM_BOT_TOKEN),
     openAiApiKey: normalizeOptionalEnv(env.OPENAI_API_KEY),
     workspaceDir: resolveWorkspaceDir(env),
-    syncTelegramCommandsOnStartup: parseBooleanEnv(env.TELEGRAM_SYNC_COMMANDS),
   };
 }
 
@@ -25,13 +23,4 @@ function normalizeOptionalEnv(value: string | undefined): string | null {
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
-}
-
-function parseBooleanEnv(value: string | undefined): boolean {
-  if (!value) {
-    return false;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,7 @@ export async function main(): Promise<void> {
   });
 
   registerBotHandlers(bot, handlers);
-  if (config.syncTelegramCommandsOnStartup) {
-    void syncTelegramCommands(bot);
-  }
+  void syncTelegramCommands(bot);
 
   if (telegramToken.source === "prompt") {
     console.info(`[codex-claw] saved TELEGRAM_BOT_TOKEN to ${localConfigStore.path}`);

--- a/tests/integration/create-bot.test.ts
+++ b/tests/integration/create-bot.test.ts
@@ -1635,7 +1635,6 @@ describe("registerBotHandlers", () => {
         telegramBotToken: null,
         openAiApiKey: "test-key",
         workspaceDir,
-        syncTelegramCommandsOnStartup: false,
       });
 
       const prompt = await deps.prepareAttachments?.({

--- a/tests/integration/cron-loader.test.ts
+++ b/tests/integration/cron-loader.test.ts
@@ -130,7 +130,6 @@ describe("createRuntimeDeps cron wiring", () => {
           telegramBotToken: null,
           openAiApiKey: null,
           workspaceDir,
-          syncTelegramCommandsOnStartup: false,
         },
         {
           createSdkRuntimeClientFn: () => ({ runTurn }),
@@ -259,7 +258,6 @@ describe("createRuntimeDeps cron wiring", () => {
           telegramBotToken: null,
           openAiApiKey: null,
           workspaceDir,
-          syncTelegramCommandsOnStartup: false,
         },
         {
           createSdkRuntimeClientFn: () => ({ runTurn }),
@@ -380,7 +378,6 @@ describe("createRuntimeDeps cron wiring", () => {
           telegramBotToken: null,
           openAiApiKey: null,
           workspaceDir,
-          syncTelegramCommandsOnStartup: false,
         },
         {
           createSdkRuntimeClientFn: () => ({ runTurn }),
@@ -503,7 +500,6 @@ describe("createRuntimeDeps cron wiring", () => {
           telegramBotToken: null,
           openAiApiKey: null,
           workspaceDir,
-          syncTelegramCommandsOnStartup: false,
         },
         {
           createSdkRuntimeClientFn: () => ({
@@ -568,7 +564,6 @@ describe("createRuntimeDeps cron wiring", () => {
           telegramBotToken: null,
           openAiApiKey: null,
           workspaceDir,
-          syncTelegramCommandsOnStartup: false,
         },
         {
           createSdkRuntimeClientFn: () => ({

--- a/tests/smoke/readme.test.ts
+++ b/tests/smoke/readme.test.ts
@@ -52,6 +52,6 @@ describe("README", () => {
     expect(readme).toContain(
       "If Telegram rejects that sync request, bot startup still continues and the CLI only logs a warning.",
     );
-    expect(readme).not.toContain("TELEGRAM_SYNC_COMMANDS=1");
+    expect(readme).not.toContain("TELEGRAM_SYNC_COMMANDS");
   });
 });

--- a/tests/smoke/readme.test.ts
+++ b/tests/smoke/readme.test.ts
@@ -46,12 +46,12 @@ describe("README", () => {
   test("documents startup Telegram command sync behavior", () => {
     const readme = readFileSync("README.md", "utf8");
 
-    expect(readme).toContain("TELEGRAM_SYNC_COMMANDS=1");
     expect(readme).toContain(
-      "When enabled, the CLI attempts to sync the Telegram slash-command menu so it stays aligned with the commands the bot actually supports.",
+      "The CLI attempts to sync the Telegram slash-command menu on startup so it stays aligned with the commands the bot actually supports.",
     );
     expect(readme).toContain(
       "If Telegram rejects that sync request, bot startup still continues and the CLI only logs a warning.",
     );
+    expect(readme).not.toContain("TELEGRAM_SYNC_COMMANDS=1");
   });
 });

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import path from "node:path";
-import { loadConfig } from "../../src/config";
 import { resolveWorkspaceDir } from "../../src/lib/paths";
+
+type ConfigModule = typeof import("../../src/config");
+
+afterEach(() => {
+  mock.restore();
+});
+
+async function loadConfigModule(): Promise<ConfigModule> {
+  return import(`../../src/config.ts?test=${Date.now()}-${Math.random()}`);
+}
 
 describe("resolveWorkspaceDir", () => {
   test("uses the default ~/.codex-claw/workspace when env is missing", () => {
@@ -29,23 +38,25 @@ describe("resolveWorkspaceDir", () => {
 });
 
 describe("loadConfig", () => {
-  test("loads the telegram token, optional OpenAI key override, and resolved workspace dir", () => {
+  test("loads the telegram token, optional OpenAI key override, and resolved workspace dir", async () => {
+    const { loadConfig } = await loadConfigModule();
+
     expect(
       loadConfig({
         TELEGRAM_BOT_TOKEN: "telegram-token",
         OPENAI_API_KEY: "openai-key",
         CODEX_WORKSPACE_DIR: "/tmp/claw",
-        TELEGRAM_SYNC_COMMANDS: "true",
       }),
     ).toEqual({
       telegramBotToken: "telegram-token",
       openAiApiKey: "openai-key",
       workspaceDir: "/tmp/claw",
-      syncTelegramCommandsOnStartup: true,
     });
   });
 
-  test("allows config without OPENAI_API_KEY so local codex login can be reused", () => {
+  test("allows config without OPENAI_API_KEY so local codex login can be reused", async () => {
+    const { loadConfig } = await loadConfigModule();
+
     expect(
       loadConfig({
         TELEGRAM_BOT_TOKEN: "telegram-token",
@@ -54,23 +65,23 @@ describe("loadConfig", () => {
       telegramBotToken: "telegram-token",
       openAiApiKey: null,
       workspaceDir: resolveWorkspaceDir({}),
-      syncTelegramCommandsOnStartup: false,
     });
   });
 
-  test("returns null token values when env overrides are missing", () => {
+  test("returns null token values when env overrides are missing", async () => {
+    const { loadConfig } = await loadConfigModule();
+
     expect(loadConfig({})).toEqual({
       telegramBotToken: null,
       openAiApiKey: null,
       workspaceDir: resolveWorkspaceDir({}),
-      syncTelegramCommandsOnStartup: false,
     });
   });
 
-  test("treats TELEGRAM_SYNC_COMMANDS as a boolean flag", () => {
-    expect(loadConfig({ TELEGRAM_SYNC_COMMANDS: "1" }).syncTelegramCommandsOnStartup).toBe(true);
-    expect(loadConfig({ TELEGRAM_SYNC_COMMANDS: "yes" }).syncTelegramCommandsOnStartup).toBe(true);
-    expect(loadConfig({ TELEGRAM_SYNC_COMMANDS: "false" }).syncTelegramCommandsOnStartup).toBe(
+  test("does not expose a Telegram command sync toggle in runtime config", async () => {
+    const { loadConfig } = await loadConfigModule();
+
+    expect("syncTelegramCommandsOnStartup" in loadConfig({ TELEGRAM_SYNC_COMMANDS: "false" })).toBe(
       false,
     );
   });

--- a/tests/unit/index-telegram-command-sync.test.ts
+++ b/tests/unit/index-telegram-command-sync.test.ts
@@ -12,7 +12,7 @@ async function loadIndexModule(): Promise<IndexModule> {
 }
 
 describe("main", () => {
-  test("does not sync Telegram commands during bot startup unless explicitly enabled", async () => {
+  test("syncs Telegram commands during bot startup by default", async () => {
     const ensureWorkspaceDirectories = mock(async () => undefined);
     const registerBotHandlers = mock((_bot: unknown, _handlers: unknown) => undefined);
     const startBackgroundServices = mock(async () => undefined);
@@ -52,74 +52,6 @@ describe("main", () => {
       loadConfig: () => ({
         telegramBotToken: undefined,
         workspaceDir: "/tmp/codex-claw-workspace",
-        syncTelegramCommandsOnStartup: false,
-      }),
-    }));
-    mock.module("../../src/config/local-config.ts", () => ({
-      createLocalConfigStore: () => ({
-        path: "/tmp/codex-claw-local-config.json",
-      }),
-    }));
-    mock.module("../../src/config/telegram-bot-token.ts", () => ({
-      ...actualTelegramBotTokenModule,
-      promptForTelegramBotToken: mock(async () => {
-        throw new Error("prompt should not be used in this test");
-      }),
-      resolveTelegramBotTokenWithStore,
-    }));
-    mock.module("../../src/runtime/create-runtime-deps.ts", () => ({ createRuntimeDeps }));
-    mock.module("../../src/runtime/workspace.ts", () => ({ ensureWorkspaceDirectories }));
-
-    const { main } = await loadIndexModule();
-    await main();
-
-    expect(syncTelegramCommands).not.toHaveBeenCalled();
-    expect(botStart).toHaveBeenCalledTimes(1);
-    expect(startBackgroundServices).toHaveBeenCalledTimes(1);
-    expect(stopBackgroundServices).toHaveBeenCalledTimes(1);
-  });
-
-  test("syncs Telegram commands during bot startup when explicitly enabled", async () => {
-    const ensureWorkspaceDirectories = mock(async () => undefined);
-    const registerBotHandlers = mock((_bot: unknown, _handlers: unknown) => undefined);
-    const startBackgroundServices = mock(async () => undefined);
-    const stopBackgroundServices = mock(() => undefined);
-    const createRuntimeDeps = mock(() => ({
-      startBackgroundServices,
-      stopBackgroundServices,
-    }));
-    const resolveTelegramBotTokenWithStore = mock(async () => ({
-      token: "telegram-token",
-      source: "env" as const,
-    }));
-    const syncTelegramCommands = mock(async () => undefined);
-    const sendMessage = mock(async () => undefined);
-    const botCatch = mock((_handler: unknown) => undefined);
-    const botStart = mock(
-      async (options?: { onStart?: (botInfo: { username: string }) => void }) => {
-        options?.onStart?.({ username: "codex-claw-bot" });
-      },
-    );
-
-    class FakeBot {
-      readonly api = {
-        sendMessage,
-      };
-
-      constructor(readonly token: string) {}
-
-      catch = botCatch;
-      start = botStart;
-    }
-
-    mock.module("grammy", () => ({ Bot: FakeBot }));
-    mock.module("../../src/bot/create-bot.ts", () => ({ registerBotHandlers }));
-    mock.module("../../src/bot/telegram-command-sync.ts", () => ({ syncTelegramCommands }));
-    mock.module("../../src/config.ts", () => ({
-      loadConfig: () => ({
-        telegramBotToken: undefined,
-        workspaceDir: "/tmp/codex-claw-workspace",
-        syncTelegramCommandsOnStartup: true,
       }),
     }));
     mock.module("../../src/config/local-config.ts", () => ({
@@ -147,7 +79,74 @@ describe("main", () => {
     expect(stopBackgroundServices).toHaveBeenCalledTimes(1);
   });
 
-  test("does not wait for syncTelegramCommands before starting the bot when sync is enabled", async () => {
+  test("keeps startup wiring working when the sync call resolves", async () => {
+    const ensureWorkspaceDirectories = mock(async () => undefined);
+    const registerBotHandlers = mock((_bot: unknown, _handlers: unknown) => undefined);
+    const startBackgroundServices = mock(async () => undefined);
+    const stopBackgroundServices = mock(() => undefined);
+    const createRuntimeDeps = mock(() => ({
+      startBackgroundServices,
+      stopBackgroundServices,
+    }));
+    const resolveTelegramBotTokenWithStore = mock(async () => ({
+      token: "telegram-token",
+      source: "env" as const,
+    }));
+    const syncTelegramCommands = mock(async () => undefined);
+    const sendMessage = mock(async () => undefined);
+    const botCatch = mock((_handler: unknown) => undefined);
+    const botStart = mock(
+      async (options?: { onStart?: (botInfo: { username: string }) => void }) => {
+        options?.onStart?.({ username: "codex-claw-bot" });
+      },
+    );
+
+    class FakeBot {
+      readonly api = {
+        sendMessage,
+      };
+
+      constructor(readonly token: string) {}
+
+      catch = botCatch;
+      start = botStart;
+    }
+
+    mock.module("grammy", () => ({ Bot: FakeBot }));
+    mock.module("../../src/bot/create-bot.ts", () => ({ registerBotHandlers }));
+    mock.module("../../src/bot/telegram-command-sync.ts", () => ({ syncTelegramCommands }));
+    mock.module("../../src/config.ts", () => ({
+      loadConfig: () => ({
+        telegramBotToken: undefined,
+        workspaceDir: "/tmp/codex-claw-workspace",
+      }),
+    }));
+    mock.module("../../src/config/local-config.ts", () => ({
+      createLocalConfigStore: () => ({
+        path: "/tmp/codex-claw-local-config.json",
+      }),
+    }));
+    mock.module("../../src/config/telegram-bot-token.ts", () => ({
+      ...actualTelegramBotTokenModule,
+      promptForTelegramBotToken: mock(async () => {
+        throw new Error("prompt should not be used in this test");
+      }),
+      resolveTelegramBotTokenWithStore,
+    }));
+    mock.module("../../src/runtime/create-runtime-deps.ts", () => ({ createRuntimeDeps }));
+    mock.module("../../src/runtime/workspace.ts", () => ({ ensureWorkspaceDirectories }));
+
+    const { main } = await loadIndexModule();
+    await main();
+
+    expect(syncTelegramCommands).toHaveBeenCalledTimes(1);
+    expect(syncTelegramCommands).toHaveBeenCalledWith(expect.any(FakeBot));
+    expect(botStart).toHaveBeenCalledTimes(1);
+    expect(startBackgroundServices).toHaveBeenCalledTimes(1);
+    expect(stopBackgroundServices).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not wait for syncTelegramCommands before starting the bot", async () => {
     const ensureWorkspaceDirectories = mock(async () => undefined);
     const registerBotHandlers = mock((_bot: unknown, _handlers: unknown) => undefined);
     const startBackgroundServices = mock(async () => undefined);
@@ -192,7 +191,6 @@ describe("main", () => {
       loadConfig: () => ({
         telegramBotToken: undefined,
         workspaceDir: "/tmp/codex-claw-workspace",
-        syncTelegramCommandsOnStartup: true,
       }),
     }));
     mock.module("../../src/config/local-config.ts", () => ({

--- a/tests/unit/index-telegram-command-sync.test.ts
+++ b/tests/unit/index-telegram-command-sync.test.ts
@@ -167,9 +167,14 @@ describe("main", () => {
     );
     const sendMessage = mock(async () => undefined);
     const botCatch = mock((_handler: unknown) => undefined);
+    let resolveBotStartReached!: () => void;
+    const botStartReached = new Promise<void>((resolve) => {
+      resolveBotStartReached = resolve;
+    });
     const botStart = mock(
       async (options?: { onStart?: (botInfo: { username: string }) => void }) => {
         options?.onStart?.({ username: "codex-claw-bot" });
+        resolveBotStartReached();
       },
     );
 
@@ -211,14 +216,8 @@ describe("main", () => {
     const { main } = await loadIndexModule();
     const startup = main();
 
-    await expect(
-      Promise.race([
-        startup.then(() => "resolved"),
-        new Promise<string>((resolve) => {
-          setTimeout(() => resolve("timed-out"), 20);
-        }),
-      ]),
-    ).resolves.toBe("resolved");
+    await botStartReached;
+    await expect(startup).resolves.toBeUndefined();
 
     expect(syncTelegramCommands).toHaveBeenCalledTimes(1);
     expect(botStart).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- remove the `TELEGRAM_SYNC_COMMANDS` startup gate so Telegram slash-command sync is always attempted on startup
- update README and focused tests to match the always-on command sync contract
- stabilize `config.test` under combined execution by avoiding leaked module mocks from startup tests

Closes #36.

## Test Plan
- `bun test tests/unit/config.test.ts tests/unit/index-telegram-command-sync.test.ts tests/smoke/readme.test.ts`
- `bun run typecheck`
- `bun test` is still not fully green because of pre-existing baseline failures tracked in #37 (`141 pass, 11 fail, 1 error` on this branch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Features**
  * Telegram slash-command menu synchronization now runs automatically during bot startup and no longer requires a runtime toggle.

* **Documentation**
  * Updated README and docs to describe automatic startup synchronization and adjusted guidance/warnings for sync failures.

* **Tests**
  * Test suite updated to reflect default-on startup sync behavior and to verify startup does not wait for sync to complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->